### PR TITLE
fix: unmarshal KCLRun config before transforming resources

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
 	"helm.sh/helm/v3/pkg/chart"
 	"kcl-lang.io/helm-kcl/pkg/config"
 	"kcl-lang.io/helm-kcl/pkg/helm"
@@ -112,6 +113,9 @@ func (app *App) doMutate(manifests, fnCfg []byte) (string, error) {
 		FunctionConfig: functionConfig,
 	}
 	r := &config.KCLRun{}
+	if err := yaml.Unmarshal(fnCfg, r); err != nil {
+		return "", err
+	}
 	err = r.TransformResourceList(resourceList)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fixes #125.

`doMutate()` constructed an empty `config.KCLRun{}` and called `TransformResourceList` on it, so the KCL program in `spec.source` of the `--file` config was never executed — krm-kcl's `Transform` reads the source from the receiver's `Spec.Source`, which stayed empty. Every `helm kcl template` invocation printed `{}` with exit code 0 (including the bundled `examples/workload-charts-with-kcl`), and all KCL errors were unreachable.

Unmarshal the function config into the `KCLRun` before transforming, so the user's KCL source actually runs.

**Before** (bundled example):

```console
$ helm kcl template --file ./kcl-run.yaml
{}
```

**After**: the example renders the full Service + Deployment, with the `managed-by: helm-kcl-plugin` annotation applied to the Deployment only, as the example's `spec.source` intends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)